### PR TITLE
Modify hardcoded urls to use route helper function (Don't merge this PR for Educational Purpose)

### DIFF
--- a/resources/views/floors/index.blade.php
+++ b/resources/views/floors/index.blade.php
@@ -35,7 +35,7 @@
         $('#users-table').DataTable({
            processing: true,
            serverSide: true,
-            ajax: 'http://localhost:8000/floors/getdatatable' ,
+            ajax: '{{route("floors.dataTables")}}' ,
             data : {'_token' : '{{csrf_token()}}'},
             columns: [
             {data: 'number'},

--- a/resources/views/rooms/index.blade.php
+++ b/resources/views/rooms/index.blade.php
@@ -38,7 +38,7 @@
         $('#rooms-table').DataTable({
            processing: true,
            serverSide: true,
-            ajax: 'http://localhost:8000/rooms/getdatatable' ,
+            ajax: '{{route('rooms.dataTables')}}' ,
             data : {'_token' : '{{csrf_token()}}'},
             columns: [
             {data: 'number'},

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,7 +118,7 @@ Aya Section
 */
 ########## Floors Routes ############
 Route::get('floors','FloorsController@index')->middleware('auth','role:admin|manager','forbid-banned-user');
-Route::get('floors/getdatatable','FloorsController@getdatatable')->middleware('auth','role:admin|manager','forbid-banned-user');
+Route::get('floors/getdatatable','FloorsController@getdatatable')->middleware('auth','role:admin|manager','forbid-banned-user')->name('floors.dataTables');
 Route::get('floors/create','FloorsController@create')->middleware('auth','role:admin|manager','forbid-banned-user');
 Route::post('floors','FloorsController@store')->middleware('auth','role:admin|manager','forbid-banned-user');
 Route::get('floors/{id}/edit','FloorsController@edit')->middleware('auth','role:admin|manager','forbid-banned-user');
@@ -128,7 +128,7 @@ Route::delete('floors/{id}', 'FloorsController@delete')->middleware('auth','role
 #### Rooms Routes #################
 */
 Route::get('rooms','RoomsController@index')->middleware('auth','role:admin|manager','forbid-banned-user');
-Route::get('rooms/getdatatable','RoomsController@getdatatable')->middleware('auth','role:admin|manager','forbid-banned-user');
+Route::get('rooms/getdatatable','RoomsController@getdatatable')->middleware('auth','role:admin|manager','forbid-banned-user')->name('rooms.dataTables');
 Route::get('rooms/create','RoomsController@create')->middleware('auth','role:admin|manager','forbid-banned-user');
 Route::post('rooms','RoomsController@store')->middleware('auth','role:admin|manager','forbid-banned-user');
 Route::get('rooms/{id}/edit','RoomsController@edit')->middleware('auth','role:admin|manager','forbid-banned-user');


### PR DESCRIPTION
i think if we used **named routes** we can solve the issue of **hard coded urls** , for example if i run the artisan serve command on **port 9000** the hard coded urls won't work , also i noticed that you did this in other view files [like this one](https://github.com/deenaahmed/Laravel-project-simple-hotel-system/blob/master/resources/views/receptionists/index.blade.php#L35)